### PR TITLE
Use base16-builder-go to automatically generate colorschemes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @base16-project/i3

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update with the latest base16 colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: base16-project/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest base16-project colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # base16-i3
 
 This repository is meant to work with
-[chriskempson/base16](https://github.com/chriskempson/base16).
+[base16-project/home](https://github.com/base16-project/home).
 It provides a simple template that can be used with the base16 color schemes to
 generate a functional config file for
 [i3/i3](https://github.com/i3/i3),
@@ -10,7 +10,7 @@ a tiling and dynamic window manager.
 To use, you can copy one of the config files in themes/ or use curl. First up, you'll want to generate a starting i3 configuration using `i3-config-wizard`. Then you can
 
 ```
-$ curl https://raw.githubusercontent.com/khamer/base16-i3/master/themes/base16-default-dark.config >> ~/.config/i3/config
+$ curl https://raw.githubusercontent.com/base16-project/base16-i3/master/themes/base16-default-dark.config >> ~/.config/i3/config
 ```
 
 Note that this will create a second bar because it provides a `bar { ... }` section. You can choose which you'd like.
@@ -18,7 +18,7 @@ Note that this will create a second bar because it provides a `bar { ... }` sect
 Alternatively, you can fetch just the base16 colors in a format for the i3 config to use them as variables:
 
 ```
-$ curl https://raw.githubusercontent.com/khamer/base16-i3/master/colors/base16-default-dark.config >> ~/.config/i3/config
+$ curl https://raw.githubusercontent.com/base16-project/base16-i3/master/colors/base16-default-dark.config >> ~/.config/i3/config
 ```
 
 The benefit of this approach is you can reference the base16 colors through out
@@ -34,7 +34,7 @@ bindsym $mod+Shift+c exec "cat .config/i3/colors .config/i3/base > .config/i3/co
 So you can now run
 
 ```
-$ curl https://raw.githubusercontent.com/khamer/base16-i3/master/colors/base16-default-dark.config > ~/.config/i3/colors
+$ curl https://raw.githubusercontent.com/base16-project/base16-i3/master/colors/base16-default-dark.config > ~/.config/i3/colors
 ```
 
 And hit **$mod + Shift + c** to load in the new colors.


### PR DESCRIPTION
- Add feature where base16-builder-go is automatically run by a github action once a week to generate the colorschemes.
- Add codeowners file to automatically tag base16-termite maintainers when a PR or issue is created (currently that's only you :smiley:)