### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/i3
+* @tinted-theming/i3

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16 colorschemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Kevin Hamer
+Copyright (c) 2022 Tinted Theming
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # base16-i3
 
 This repository is meant to work with
-[base16-project/home](https://github.com/base16-project/home).
+[tinted-theming/home](https://github.com/tinted-theming/home).
 It provides a simple template that can be used with the base16 color schemes to
 generate a functional config file for
 [i3/i3](https://github.com/i3/i3),
@@ -10,7 +10,7 @@ a tiling and dynamic window manager.
 To use, you can copy one of the config files in themes/ or use curl. First up, you'll want to generate a starting i3 configuration using `i3-config-wizard`. Then you can
 
 ```
-$ curl https://raw.githubusercontent.com/base16-project/base16-i3/master/themes/base16-default-dark.config >> ~/.config/i3/config
+$ curl https://raw.githubusercontent.com/tinted-theming/base16-i3/master/themes/base16-default-dark.config >> ~/.config/i3/config
 ```
 
 Note that this will create a second bar because it provides a `bar { ... }` section. You can choose which you'd like.
@@ -18,7 +18,7 @@ Note that this will create a second bar because it provides a `bar { ... }` sect
 Alternatively, you can fetch just the base16 colors in a format for the i3 config to use them as variables:
 
 ```
-$ curl https://raw.githubusercontent.com/base16-project/base16-i3/master/colors/base16-default-dark.config >> ~/.config/i3/config
+$ curl https://raw.githubusercontent.com/tinted-theming/base16-i3/master/colors/base16-default-dark.config >> ~/.config/i3/config
 ```
 
 The benefit of this approach is you can reference the base16 colors through out
@@ -34,7 +34,7 @@ bindsym $mod+Shift+c exec "cat .config/i3/colors .config/i3/base > .config/i3/co
 So you can now run
 
 ```
-$ curl https://raw.githubusercontent.com/base16-project/base16-i3/master/colors/base16-default-dark.config > ~/.config/i3/colors
+$ curl https://raw.githubusercontent.com/tinted-theming/base16-i3/master/colors/base16-default-dark.config > ~/.config/i3/colors
 ```
 
 And hit **$mod + Shift + c** to load in the new colors.

--- a/templates/colors.mustache
+++ b/templates/colors.mustache
@@ -1,5 +1,6 @@
 ## Base16 {{scheme-name}}
-# Author: {{scheme-author}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 #
 # You can use these variables anywhere in the i3 configuration file.
 

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,5 +1,6 @@
 ## Base16 {{scheme-name}}
-# Author: {{scheme-author}}
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 #
 # You can use these variables anywhere in the i3 configuration file.
 


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.