### PR TITLE
Remove the hardcoded bar

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -21,24 +21,6 @@ set $base0D #{{base0D-hex}}
 set $base0E #{{base0E-hex}}
 set $base0F #{{base0F-hex}}
 
-# Basic bar configuration using the Base16 variables.
-bar {
-    status_command i3status
-
-    colors {
-        background $base00
-        separator  $base01
-        statusline $base04
-
-        # State             Border  BG      Text
-        focused_workspace   $base05 $base0D $base00
-        active_workspace    $base05 $base03 $base00
-        inactive_workspace  $base03 $base01 $base05
-        urgent_workspace    $base08 $base08 $base00
-        binding_mode        $base00 $base0A $base00
-    }
-}
-
 # Basic color configuration using the Base16 variables for windows and borders.
 # Property Name         Border  BG      Text    Indicator Child Border
 client.focused          $base05 $base0D $base00 $base0D $base0C


### PR DESCRIPTION
Remove the bar. The user should maintain their own bar(s) and just import the colors as needed with `include`.