### PR TITLE
Use tinted-builder-rust for weekly builds

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: tinted-theming/base16-builder-go@latest
+        uses: tinted-theming/tinted-builder-rust@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
We've built `tinted-builder-rust` and are using it as the primary builder for all repos https://github.com/tinted-theming/tinted-builder-rust